### PR TITLE
Feature/chapter order

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -188,6 +188,8 @@ claude_plans
 
 # Local testing docker-compose
 docker-compose.local.yml
+data/
+stories/
 
 routes.py.backup
 

--- a/app/blueprints/api/routes.py
+++ b/app/blueprints/api/routes.py
@@ -27,16 +27,18 @@ def queue_download() -> ResponseReturnValue:
             data = request.get_json()
             url = data.get('url', '')
             extra_urls = data.get('extra_urls', data.get('urls', []))
+            chapter_order = data.get('chapter_order')
         else:
             url = request.form.get('url', '')
             extra_urls = request.form.getlist('extra_urls') or request.form.getlist('urls')
+            chapter_order = None
 
         if extra_urls and not url:
             url = extra_urls[0]
             extra_urls = extra_urls[1:]
 
         formats = ['epub', 'html']
-        validated = StoryDownloadRequest(url=url, format=formats)
+        validated = StoryDownloadRequest(url=url, format=formats, chapter_order=chapter_order)
 
     except ValidationError as e:
         error_details = e.errors()[0]
@@ -82,6 +84,8 @@ def queue_download() -> ResponseReturnValue:
         queue_item.set_formats(validated.format)
         if is_multi:
             queue_item.set_extra_urls(list(extra_urls))
+        elif validated.chapter_order:
+            queue_item.set_chapter_order(validated.chapter_order)
         db.session.add(queue_item)
         db.session.commit()
         current_app.download_worker.wake()
@@ -159,6 +163,63 @@ def preview_story() -> ResponseReturnValue:
         return jsonify({
             "success": False,
             "message": "An error occurred while fetching story metadata"
+        }), 500
+
+@api.route("/series/preview", methods=['POST'])
+def preview_series_chapters() -> ResponseReturnValue:
+    """Resolve a chapter/series URL to its ordered chapter list without downloading any content.
+
+    Used by the chapter-order preview modal on the download form; does not create a queue item.
+    """
+    try:
+        data = request.get_json() or {}
+        url = (data.get('url') or '').strip()
+        if not url:
+            return jsonify({"success": False, "message": "url is required"}), 400
+
+        validated = StoryDownloadRequest(url=url, format=['epub', 'html'])
+
+    except ValidationError as e:
+        error_details = e.errors()[0]
+        error_msg = f"{error_details['loc'][0]}: {error_details['msg']}"
+        return jsonify({"success": False, "message": error_msg}), 400
+
+    try:
+        from app.services.story_downloader import detect_url_type, extract_series_url_from_chapter
+        from app.services.series_page_checker import SeriesPageChecker
+        from app.services.http_client import get_session, global_rate_limiter
+
+        session = get_session()
+        target_url = validated.url.split('?')[0]
+        url_type, series_url = detect_url_type(target_url)
+
+        if url_type == 'chapter':
+            global_rate_limiter.wait_if_needed()
+            series_url = extract_series_url_from_chapter(target_url, session)
+
+        if not series_url:
+            return jsonify({"success": True, "is_series": False})
+
+        global_rate_limiter.wait_if_needed()
+        series_info = SeriesPageChecker().check_series_parts(series_url)
+
+        parts = (series_info or {}).get('parts') or []
+        if len(parts) <= 1:
+            return jsonify({"success": True, "is_series": False})
+
+        return jsonify({
+            "success": True,
+            "is_series": True,
+            "series_title": series_info.get('series_title') or '',
+            "series_url": series_url,
+            "parts": parts,
+        })
+
+    except Exception as e:
+        log_error(f"Error previewing series chapters: {str(e)}\n{traceback.format_exc()}")
+        return jsonify({
+            "success": False,
+            "message": "Failed to resolve chapter list. Please try again."
         }), 500
 
 @api.route("/save", methods=['POST'])

--- a/app/models/download_queue.py
+++ b/app/models/download_queue.py
@@ -22,6 +22,7 @@ class DownloadQueueItem(BaseModel, TimestampMixin):
 
     job_type = db.Column(db.String(20), nullable=False, default='single')
     extra_urls = db.Column(db.Text)
+    chapter_order = db.Column(db.Text)
     scheduled_after = db.Column(db.DateTime, nullable=True)
 
     total_pages = db.Column(db.Integer)
@@ -79,6 +80,19 @@ class DownloadQueueItem(BaseModel, TimestampMixin):
     def set_extra_urls(self, urls: list[str]) -> None:
         """Store extra URLs as JSON string"""
         self.extra_urls = json.dumps(urls) if urls else None
+
+    def get_chapter_order(self) -> Optional[list[str]]:
+        """Parse the user-confirmed chapter URL order from JSON string"""
+        if not self.chapter_order:
+            return None
+        try:
+            return json.loads(self.chapter_order)
+        except (json.JSONDecodeError, ValueError):
+            return None
+
+    def set_chapter_order(self, urls: Optional[list[str]]) -> None:
+        """Store the user-confirmed chapter URL order as JSON string"""
+        self.chapter_order = json.dumps(urls) if urls else None
 
     def get_queue_position(self) -> int:
         """Get position in queue (1-indexed)"""

--- a/app/services/download_queue_worker.py
+++ b/app/services/download_queue_worker.py
@@ -255,7 +255,7 @@ class DownloadQueueWorker:
         item.progress_message = 'Downloading story content...'
         db.session.commit()
 
-        story_data = download_story(item.url)
+        story_data = download_story(item.url, chapter_order=item.get_chapter_order())
         story_content, title, author, category, tags, author_url, page_count, series_url, story_description = story_data
 
         if not story_content or not title:

--- a/app/services/story_downloader.py
+++ b/app/services/story_downloader.py
@@ -200,12 +200,43 @@ def _download_single_chapter(
     metadata['page_count'] = page_count
     return chapter_content, metadata
 
+def _reorder_parts(parts: list[dict], chapter_order: list[str]) -> list[dict]:
+    """Reorder freshly-fetched series parts according to a user-confirmed URL order.
+
+    Parts whose URL isn't in chapter_order (e.g. published after the preview was
+    shown) are appended at the end in their original (API) order. Entries in
+    chapter_order that no longer match a fetched part (e.g. removed since the
+    preview) are simply skipped.
+    """
+    from .logger import log_action
+
+    parts_by_url = {p['url']: p for p in parts}
+    ordered = [parts_by_url[u] for u in chapter_order if u in parts_by_url]
+
+    ordered_urls = {p['url'] for p in ordered}
+    leftovers = [p for p in parts if p['url'] not in ordered_urls]
+    if leftovers:
+        log_action(f"chapter_order: {len(leftovers)} part(s) not in confirmed order, appending at the end")
+
+    missing = [u for u in chapter_order if u not in parts_by_url]
+    if missing:
+        log_action(f"chapter_order: {len(missing)} confirmed URL(s) no longer present in series, skipping")
+
+    return ordered + leftovers
+
+
 def _download_from_series_page(
     series_url: str,
-    session: requests.Session
+    session: requests.Session,
+    chapter_order: Optional[list[str]] = None
 ) -> Optional[tuple[str, str, str, Optional[str], Optional[list[str]], Optional[str], int, str, Optional[str]]]:
     """
     Download complete story using series page as source of truth.
+
+    Args:
+        chapter_order: optional list of chapter URLs in the order confirmed by the
+            user in the chapter-order preview modal. When provided, the freshly
+            fetched parts are reordered to match before downloading.
 
     Returns:
         Same tuple as download_story() or None if failed
@@ -223,6 +254,8 @@ def _download_from_series_page(
 
         series_title = series_info.get('series_title', 'Unknown Series')
         parts = series_info['parts']
+        if chapter_order:
+            parts = _reorder_parts(parts, chapter_order)
         total_parts = len(parts)
         series_description = series_info.get('description')
 
@@ -287,11 +320,16 @@ def _download_from_series_page(
         log_error(f"Error in series-first download: {str(e)}", series_url)
         return None
 
-def download_story(url: str) -> tuple[Optional[str], Optional[str], Optional[str], Optional[str], Optional[list[str]], Optional[str], Optional[int], Optional[str], Optional[str]]:
-    """Download and extract the full story content and metadata from the given Literotica URL."""
+def download_story(url: str, chapter_order: Optional[list[str]] = None) -> tuple[Optional[str], Optional[str], Optional[str], Optional[str], Optional[list[str]], Optional[str], Optional[int], Optional[str], Optional[str]]:
+    """Download and extract the full story content and metadata from the given Literotica URL.
+
+    Args:
+        chapter_order: optional list of chapter URLs, in the order confirmed by the
+            user in the chapter-order preview modal. Only applies to series downloads.
+    """
     try:
         session = get_session()
-        
+
         url = url.split('?')[0]
         from .logger import log_action
         log_action(f"Normalized URL to start from page 1: {url}")
@@ -304,7 +342,7 @@ def download_story(url: str) -> tuple[Optional[str], Optional[str], Optional[str
 
         if series_url:
             try:
-                result = _download_from_series_page(series_url, session)
+                result = _download_from_series_page(series_url, session, chapter_order=chapter_order)
                 if result:
                     log_url(f"Successfully downloaded via series page")
                     return result

--- a/app/templates/components/chapter_order_modal.html
+++ b/app/templates/components/chapter_order_modal.html
@@ -1,0 +1,166 @@
+<div id="chapterOrderModal" class="hidden fixed inset-0 bg-black/50 z-[60] flex items-center justify-center p-4" onclick="closeChapterOrderModal()">
+  <div class="bg-white dark:bg-slate-800 rounded-lg shadow-xl max-w-2xl w-full max-h-[90vh] flex flex-col" onclick="event.stopPropagation()">
+
+    <!-- Header -->
+    <div class="flex items-center justify-between p-6 border-b border-slate-200 dark:border-slate-700 flex-shrink-0">
+      <div class="min-w-0">
+        <h3 class="text-lg font-semibold text-slate-900 dark:text-white truncate" id="chapterOrderTitle">Chapter Order Preview</h3>
+        <p class="text-sm text-slate-500 dark:text-slate-400 mt-0.5" id="chapterOrderSubtitle"></p>
+      </div>
+      <button onclick="closeChapterOrderModal()" class="text-slate-400 hover:text-slate-600 dark:hover:text-slate-300 transition-colors ml-4 flex-shrink-0">
+        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
+        </svg>
+      </button>
+    </div>
+
+    <!-- Body -->
+    <div class="flex-1 overflow-hidden flex flex-col min-h-0">
+      <p class="text-xs text-slate-500 dark:text-slate-400 px-6 pt-4 pb-1 flex-shrink-0">
+        Drag chapters (or use the arrows) to fix the reading order. Chapter numbers below show how the finished book will be numbered.
+      </p>
+      <div id="chapterOrderList" class="flex-1 overflow-y-auto px-6 py-2 space-y-1.5">
+        <!-- Populated by JS -->
+      </div>
+    </div>
+
+    <!-- Footer -->
+    <div class="flex-shrink-0 border-t border-slate-200 dark:border-slate-700 px-6 py-4 flex items-center justify-end gap-3">
+      <button onclick="closeChapterOrderModal()"
+        class="px-4 py-2 text-sm font-medium rounded-lg border border-slate-300 dark:border-slate-500 bg-white dark:bg-slate-700 text-slate-700 dark:text-slate-200 hover:bg-slate-50 dark:hover:bg-slate-600 transition-all duration-200">
+        Cancel
+      </button>
+      <button id="chapterOrderConfirmBtn" onclick="confirmChapterOrder()"
+        class="px-4 py-2 text-sm font-semibold rounded-lg bg-slate-900 dark:bg-slate-100 text-white dark:text-slate-900 hover:bg-slate-700 dark:hover:bg-slate-300 transition-all duration-200">
+        Download
+      </button>
+    </div>
+
+  </div>
+</div>
+
+<script>
+let _chapterOrderUrl = null;
+let _chapterOrderExtraUrls = [];
+let _chapterOrderParts = [];
+let _chapterOrderDragUrl = null;
+
+function openChapterOrderModal(url, seriesTitle, parts, extraUrls) {
+  _chapterOrderUrl = url;
+  _chapterOrderExtraUrls = extraUrls || [];
+  _chapterOrderParts = parts.map(p => ({ title: p.title, url: p.url }));
+
+  document.getElementById('chapterOrderTitle').textContent = seriesTitle || 'Chapter Order Preview';
+  document.getElementById('chapterOrderSubtitle').textContent =
+    `${_chapterOrderParts.length} chapters found — review the order before downloading`;
+
+  _renderChapterOrderList();
+
+  if (typeof closeStoryModal === 'function') closeStoryModal();
+
+  document.getElementById('chapterOrderModal').classList.remove('hidden');
+  document.documentElement.style.overflow = 'hidden';
+  document.body.style.overflow = 'hidden';
+}
+
+function closeChapterOrderModal() {
+  document.getElementById('chapterOrderModal').classList.add('hidden');
+  document.documentElement.style.overflow = '';
+  document.body.style.overflow = '';
+}
+
+function _moveChapterOrderItem(fromIndex, toIndex) {
+  if (toIndex < 0 || toIndex >= _chapterOrderParts.length) return;
+  const [item] = _chapterOrderParts.splice(fromIndex, 1);
+  _chapterOrderParts.splice(toIndex, 0, item);
+  _renderChapterOrderList();
+}
+
+function _renderChapterOrderList() {
+  const list = document.getElementById('chapterOrderList');
+
+  list.innerHTML = _chapterOrderParts.map((part, i) => `
+    <div draggable="true"
+      data-url="${_escAttrCO(part.url)}"
+      ondragstart="_onChapterOrderDragStart(event, '${_escAttrCO(part.url)}')"
+      ondragover="_onChapterOrderDragOver(event)"
+      ondrop="_onChapterOrderDrop(event, '${_escAttrCO(part.url)}')"
+      ondragend="_onChapterOrderDragEnd(event)"
+      class="chapter-order-row flex items-center gap-3 px-3 py-2.5 rounded-lg border border-slate-100 dark:border-slate-700 bg-white dark:bg-slate-800/60 hover:bg-slate-50 dark:hover:bg-slate-700/40 transition-colors cursor-grab active:cursor-grabbing">
+      <svg class="w-4 h-4 text-slate-300 dark:text-slate-600 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M8 6h.01M8 12h.01M8 18h.01M16 6h.01M16 12h.01M16 18h.01"/>
+      </svg>
+      <span class="flex-shrink-0 w-16 text-xs font-semibold text-slate-400 dark:text-slate-500">Chapter ${i + 1}</span>
+      <span class="flex-1 min-w-0 text-sm text-slate-900 dark:text-white truncate">${_escHtmlCO(part.title)}</span>
+      <div class="flex-shrink-0 flex items-center gap-0.5">
+        <button type="button" onclick="_moveChapterOrderItem(${i}, ${i - 1})" ${i === 0 ? 'disabled' : ''}
+          class="p-1 rounded text-slate-400 hover:text-slate-700 dark:hover:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-600 disabled:opacity-30 disabled:cursor-not-allowed transition-colors" title="Move up">
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M5 15l7-7 7 7"/></svg>
+        </button>
+        <button type="button" onclick="_moveChapterOrderItem(${i}, ${i + 1})" ${i === _chapterOrderParts.length - 1 ? 'disabled' : ''}
+          class="p-1 rounded text-slate-400 hover:text-slate-700 dark:hover:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-600 disabled:opacity-30 disabled:cursor-not-allowed transition-colors" title="Move down">
+          <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7"/></svg>
+        </button>
+      </div>
+    </div>`).join('');
+}
+
+function _onChapterOrderDragStart(e, url) {
+  _chapterOrderDragUrl = url;
+  e.dataTransfer.effectAllowed = 'move';
+  e.dataTransfer.setData('text/plain', url);
+  e.currentTarget.classList.add('opacity-40');
+}
+
+function _onChapterOrderDragOver(e) {
+  e.preventDefault();
+  e.dataTransfer.dropEffect = 'move';
+  e.currentTarget.classList.add('bg-slate-100', 'dark:bg-slate-600/40');
+}
+
+function _onChapterOrderDrop(e, targetUrl) {
+  e.preventDefault();
+  e.currentTarget.classList.remove('bg-slate-100', 'dark:bg-slate-600/40');
+
+  const sourceUrl = _chapterOrderDragUrl;
+  if (!sourceUrl || sourceUrl === targetUrl) return;
+
+  const fromIndex = _chapterOrderParts.findIndex(p => p.url === sourceUrl);
+  const toIndex = _chapterOrderParts.findIndex(p => p.url === targetUrl);
+  if (fromIndex === -1 || toIndex === -1) return;
+
+  _moveChapterOrderItem(fromIndex, toIndex);
+}
+
+function _onChapterOrderDragEnd(e) {
+  _chapterOrderDragUrl = null;
+  document.querySelectorAll('#chapterOrderList .chapter-order-row').forEach(row => {
+    row.classList.remove('opacity-40', 'bg-slate-100', 'dark:bg-slate-600/40');
+  });
+}
+
+async function confirmChapterOrder() {
+  const btn = document.getElementById('chapterOrderConfirmBtn');
+  btn.disabled = true;
+  btn.textContent = 'Queuing…';
+
+  const orderedUrls = _chapterOrderParts.map(p => p.url);
+  try {
+    await submitDownload(_chapterOrderUrl, _chapterOrderExtraUrls, orderedUrls);
+  } finally {
+    btn.disabled = false;
+    btn.textContent = 'Download';
+    closeChapterOrderModal();
+  }
+}
+
+function _escHtmlCO(str) {
+  if (!str) return '';
+  return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+}
+
+function _escAttrCO(str) {
+  if (!str) return '';
+  return str.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+}
+</script>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -108,14 +108,14 @@ if (sessionStorage.getItem('syncBannerDismissed') === 'true') {
         Download
       </button>
 
-      <label class="inline-flex items-center gap-2 cursor-pointer select-none"
+      <label id="previewOrderLabel" class="inline-flex items-center gap-2 cursor-pointer select-none"
         title="Preview and reorder the chapter list before a series is downloaded">
         <button type="button" id="previewOrderToggle" role="switch" aria-checked="false"
           onclick="togglePreviewOrderSwitch()"
-          class="relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 bg-slate-200 dark:bg-slate-600">
+          class="relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 bg-slate-200 dark:bg-slate-600 disabled:opacity-40 disabled:cursor-not-allowed">
           <span class="pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out translate-x-0"></span>
         </button>
-        <span class="text-sm text-gray-600 dark:text-gray-400">Preview chapter order</span>
+        <span id="previewOrderLabelText" class="text-sm text-gray-600 dark:text-gray-400">Preview chapter order</span>
       </label>
 
       <a href="/queue/" hx-boost="false"
@@ -234,20 +234,40 @@ function toggleAddStories() {
     if (!btn) return;
     const enabled = isPreviewOrderEnabled();
     btn.setAttribute('aria-checked', String(enabled));
-    btn.classList.toggle('bg-green-600', enabled);
-    btn.classList.toggle('bg-slate-200', !enabled);
-    btn.classList.toggle('dark:bg-slate-600', !enabled);
+    btn.classList.toggle('bg-green-600', enabled && !btn.disabled);
+    btn.classList.toggle('bg-slate-200', !enabled || btn.disabled);
+    btn.classList.toggle('dark:bg-slate-600', !enabled || btn.disabled);
     const knob = btn.querySelector('span');
     knob.classList.toggle('translate-x-5', enabled);
     knob.classList.toggle('translate-x-0', !enabled);
   }
 
   function togglePreviewOrderSwitch() {
+    const btn = document.getElementById('previewOrderToggle');
+    if (btn && btn.disabled) return;
     localStorage.setItem(PREVIEW_ORDER_KEY, String(!isPreviewOrderEnabled()));
     _syncPreviewOrderToggleUI();
   }
 
-  _syncPreviewOrderToggleUI();
+  function _syncPreviewOrderAvailability() {
+    const section = document.getElementById('combineSection');
+    const btn = document.getElementById('previewOrderToggle');
+    const label = document.getElementById('previewOrderLabel');
+    const labelText = document.getElementById('previewOrderLabelText');
+    if (!section || !btn) return;
+
+    const combineOpen = !section.classList.contains('hidden');
+    btn.disabled = combineOpen;
+    label.title = combineOpen
+      ? 'Not available while combining multiple stories or series into one file'
+      : 'Preview and reorder the chapter list before a series is downloaded';
+    label.classList.toggle('cursor-not-allowed', combineOpen);
+    label.classList.toggle('cursor-pointer', !combineOpen);
+    labelText.classList.toggle('opacity-40', combineOpen);
+    _syncPreviewOrderToggleUI();
+  }
+
+  _syncPreviewOrderAvailability();
 
   function closeSeriesModal() {
     document.getElementById('seriesModal').style.display = 'none';
@@ -290,6 +310,7 @@ function toggleAddStories() {
     const chevron = document.getElementById('combineChevron');
     const hidden = section.classList.toggle('hidden');
     chevron.style.transform = hidden ? '' : 'rotate(180deg)';
+    _syncPreviewOrderAvailability();
   });
 
   document.getElementById('url').addEventListener('keydown', function(e) {

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -102,11 +102,22 @@ if (sessionStorage.getItem('syncBannerDismissed') === 'true') {
       </div>
     </div>
 
-    <div class="flex flex-wrap gap-3">
+    <div class="flex flex-wrap gap-3 items-center">
       <button type="button" id="downloadBtn" data-requires-online
         class="btn-primary w-full sm:w-auto sm:px-14">
         Download
       </button>
+
+      <label class="inline-flex items-center gap-2 cursor-pointer select-none"
+        title="Preview and reorder the chapter list before a series is downloaded">
+        <button type="button" id="previewOrderToggle" role="switch" aria-checked="false"
+          onclick="togglePreviewOrderSwitch()"
+          class="relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 bg-slate-200 dark:bg-slate-600">
+          <span class="pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out translate-x-0"></span>
+        </button>
+        <span class="text-sm text-gray-600 dark:text-gray-400">Preview chapter order</span>
+      </label>
+
       <a href="/queue/" hx-boost="false"
         class="hidden sm:inline-flex items-center gap-2 px-4 py-2.5 rounded-lg border border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-700 text-slate-600 dark:text-slate-300 text-sm font-medium hover:bg-slate-50 dark:hover:bg-slate-600 transition-colors whitespace-nowrap">
         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -204,13 +215,39 @@ function toggleAddStories() {
 </div>
 
 {% include "components/author_preview_modal.html" %}
+{% include "components/chapter_order_modal.html" %}
 
 <script>
   const AUTHOR_URL_RE = /literotica\.com\/(authors?|members?)\/[^/?#]+/i;
   const SERIES_URL_RE = /literotica\.com\/series\/se\//i;
+  const PREVIEW_ORDER_KEY = 'litkeeper.previewChapterOrder';
 
   function isAuthorUrl(url) { return AUTHOR_URL_RE.test(url); }
   function isSeriesUrl(url) { return SERIES_URL_RE.test(url); }
+
+  function isPreviewOrderEnabled() {
+    return localStorage.getItem(PREVIEW_ORDER_KEY) === 'true';
+  }
+
+  function _syncPreviewOrderToggleUI() {
+    const btn = document.getElementById('previewOrderToggle');
+    if (!btn) return;
+    const enabled = isPreviewOrderEnabled();
+    btn.setAttribute('aria-checked', String(enabled));
+    btn.classList.toggle('bg-green-600', enabled);
+    btn.classList.toggle('bg-slate-200', !enabled);
+    btn.classList.toggle('dark:bg-slate-600', !enabled);
+    const knob = btn.querySelector('span');
+    knob.classList.toggle('translate-x-5', enabled);
+    knob.classList.toggle('translate-x-0', !enabled);
+  }
+
+  function togglePreviewOrderSwitch() {
+    localStorage.setItem(PREVIEW_ORDER_KEY, String(!isPreviewOrderEnabled()));
+    _syncPreviewOrderToggleUI();
+  }
+
+  _syncPreviewOrderToggleUI();
 
   function closeSeriesModal() {
     document.getElementById('seriesModal').style.display = 'none';
@@ -296,16 +333,41 @@ function toggleAddStories() {
       }
     }
 
+    // Single-URL download with chapter-order preview enabled → resolve chapters first
+    if (!combineOpen && isPreviewOrderEnabled()) {
+      const btn = document.getElementById('downloadBtn');
+      btn.disabled = true;
+      btn.textContent = 'Checking…';
+      try {
+        const res = await fetch('/api/series/preview', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ url })
+        });
+        const data = await res.json();
+        if (data.success && data.is_series && data.parts && data.parts.length > 1) {
+          openChapterOrderModal(url, data.series_title, data.parts, extraUrls);
+          return;
+        }
+      } catch {
+        // Preview resolution failed — fall through to the normal direct queue flow.
+      } finally {
+        btn.disabled = false;
+        btn.textContent = 'Download';
+      }
+    }
+
     await submitDownload(url, extraUrls);
   });
 
-  async function submitDownload(url, extraUrls) {
+  async function submitDownload(url, extraUrls, chapterOrder) {
     const btn = document.getElementById('downloadBtn');
     btn.disabled = true;
     btn.textContent = 'Queuing…';
     try {
       const body = { url };
       if (extraUrls && extraUrls.length) body.extra_urls = extraUrls;
+      if (chapterOrder && chapterOrder.length) body.chapter_order = chapterOrder;
       const res = await fetch('/api/queue', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },

--- a/app/validators.py
+++ b/app/validators.py
@@ -8,7 +8,16 @@ class StoryDownloadRequest(BaseModel):
     url: str
     wait: bool = True
     format: list[Literal["epub", "html"]] = Field(default=["epub", "html"], min_length=1)
-    
+    chapter_order: list[str] | None = None
+
+    @field_validator('chapter_order')
+    @classmethod
+    def validate_chapter_order(cls, v: list[str] | None) -> list[str] | None:
+        if v is None:
+            return None
+        cleaned = [u.strip() for u in v if isinstance(u, str) and u.strip()]
+        return cleaned or None
+
     @field_validator('url')
     @classmethod
     def validate_url(cls, v: str) -> str:

--- a/migrations/versions/20260704a_add_chapter_order_to_queue.py
+++ b/migrations/versions/20260704a_add_chapter_order_to_queue.py
@@ -1,0 +1,30 @@
+"""add chapter_order to download_queue
+
+Revision ID: 20260704a
+Revises: 91eb3b2b1034
+Create Date: 2026-07-04 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '20260704a'
+down_revision = '91eb3b2b1034'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    existing_columns = {col['name'] for col in inspector.get_columns('download_queue')}
+
+    with op.batch_alter_table('download_queue', schema=None) as batch_op:
+        if 'chapter_order' not in existing_columns:
+            batch_op.add_column(sa.Column('chapter_order', sa.Text(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table('download_queue', schema=None) as batch_op:
+        batch_op.drop_column('chapter_order')


### PR DESCRIPTION
## Summary
- Adds an optional "Preview chapter order" toggle (off by default) next to the download button. When enabled, downloading a story/series link first resolves the chapter list server-side and shows a preview modal before anything is downloaded.
- The preview modal lets the user drag-and-drop (or use up/down buttons) to reorder chapters, with chapter numbers recalculating live to show exactly how the finished book will be numbered — fixing cases where an author's chapters are mislabeled (e.g. "01, 10, 11, 12, 2, 3") and Literotica's API returns them in the wrong order.
- The confirmed order is stored on the download queue item and applied when the series is actually downloaded, so both the EPUB and web-viewer/JSON output follow the user-chosen order instead of the raw API order.
- The preview toggle is automatically disabled (with an explanatory tooltip) while "Combine multiple stories or series into one file" is open, since reordering isn't supported for combined downloads yet.

## Implementation notes
- New endpoint `POST /api/series/preview` resolves a chapter or series URL to its ordered chapter list without downloading any content (reuses existing series-resolution logic, shares the global rate limiter with the background worker).
- New `chapter_order` column on `download_queue` (migration `20260704a_add_chapter_order_to_queue.py`) persists the user-confirmed order between queuing and the async download job.
- `story_downloader.py` reorders the freshly-fetched series parts to match the confirmed order right before downloading; any chapters added/removed since the preview are handled gracefully (appended/skipped with a log entry).
- No changes needed in the EPUB/HTML generators — chapter numbering there is already purely positional, so it automatically follows the corrected order.
- No new frontend dependencies — drag-and-drop uses the native HTML5 DnD API, consistent with the project's existing vanilla-JS/htmx/Alpine stack.

## Test plan
- [ ] Apply the new migration (`flask db upgrade` or equivalent) and confirm `download_queue.chapter_order` exists.
- [ ] Enable the preview switch, download a series with a known out-of-order chapter list, reorder via drag-and-drop and via the arrow buttons, confirm, and verify the generated EPUB and web viewer reflect the chosen order and numbering.
- [ ] Confirm the switch stays off by default and its state persists across page reloads (localStorage).
- [ ] Confirm the switch is greyed out with a tooltip when the "combine stories" section is open, and that combine downloads behave exactly as before.
- [ ] Confirm a normal single-chapter (non-series) URL still queues immediately without showing the modal.
